### PR TITLE
Upgrade swagger-core and Jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,10 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 lazy val twitterReleaseVersion = "20.6.0"
 lazy val jacksonVersion = "2.10.4"
 
+// lazy val jacksonVersion = "2.11.0"
+// lazy val jacksonVersion = "2.11.0.rc1"
+// lazy val jacksonVersion = "2.10.4"
+
 lazy val swaggerUIVersion = SettingKey[String]("swaggerUIVersion")
 
 swaggerUIVersion := "3.24.3"
@@ -26,8 +30,12 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype",
     "com.fasterxml.jackson.module"
   ),
-  "io.swagger" % "swagger-core" % "1.6.1",
+  // "io.swagger" % "swagger-core" % "1.6.1",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
+  // "io.swagger.core.v3" % "swagger-core" % "2.1.3",
+  "io.swagger.core.v3" % "swagger-core" % "2.0.0",
+  // "com.github.swagger-akka-http" % "swagger-scala-module" % "2.1.2",
+  // "com.github.swagger-akka-http" %% "swagger-scala-module" % "2.1.2",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   // "io.swagger" % "swagger-core" % "1.6.1",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   // "io.swagger.core.v3" % "swagger-core" % "2.1.3",
-  "io.swagger.core.v3" % "swagger-core" % "2.0.10",
+  "io.swagger.core.v3" % "swagger-core" % "2.1.0",
   // "com.github.swagger-akka-http" % "swagger-scala-module" % "2.1.2",
   // "com.github.swagger-akka-http" %% "swagger-scala-module" % "2.1.2",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   // "io.swagger" % "swagger-core" % "1.6.1",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   // "io.swagger.core.v3" % "swagger-core" % "2.1.3",
-  "io.swagger.core.v3" % "swagger-core" % "2.0.0",
+  "io.swagger.core.v3" % "swagger-core" % "2.0.10",
   // "com.github.swagger-akka-http" % "swagger-scala-module" % "2.1.2",
   // "com.github.swagger-akka-http" %% "swagger-scala-module" % "2.1.2",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,6 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 lazy val twitterReleaseVersion = "20.6.0"
 lazy val jacksonVersion = "2.10.4"
 
-// lazy val jacksonVersion = "2.11.0"
-// lazy val jacksonVersion = "2.11.0.rc1"
-// lazy val jacksonVersion = "2.10.4"
-
 lazy val swaggerUIVersion = SettingKey[String]("swaggerUIVersion")
 
 swaggerUIVersion := "3.24.3"
@@ -30,12 +26,8 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype",
     "com.fasterxml.jackson.module"
   ),
-  // "io.swagger" % "swagger-core" % "1.6.1",
-  "io.swagger" %% "swagger-scala-module" % "1.0.6",
-  // "io.swagger.core.v3" % "swagger-core" % "2.1.3",
   "io.swagger.core.v3" % "swagger-core" % "2.1.2",
-  // "com.github.swagger-akka-http" % "swagger-scala-module" % "2.1.2",
-  // "com.github.swagger-akka-http" %% "swagger-scala-module" % "2.1.2",
+  "io.swagger" %% "swagger-scala-module" % "1.0.6",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.11")
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 lazy val twitterReleaseVersion = "20.6.0"
-lazy val jacksonVersion = "2.10.4"
+lazy val jacksonVersion = "2.11.1"
 
 lazy val swaggerUIVersion = SettingKey[String]("swaggerUIVersion")
 
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype",
     "com.fasterxml.jackson.module"
   ),
-  "io.swagger.core.v3" % "swagger-core" % "2.1.2",
+  "io.swagger.core.v3" % "swagger-core" % "2.1.3",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   // "io.swagger" % "swagger-core" % "1.6.1",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   // "io.swagger.core.v3" % "swagger-core" % "2.1.3",
-  "io.swagger.core.v3" % "swagger-core" % "2.1.0",
+  "io.swagger.core.v3" % "swagger-core" % "2.1.2",
   // "com.github.swagger-akka-http" % "swagger-scala-module" % "2.1.2",
   // "com.github.swagger-akka-http" %% "swagger-scala-module" % "2.1.2",
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,


### PR DESCRIPTION
Reproduce https://github.com/swagger-api/swagger-core/issues/3554. 

Run `sbt "project hello-world-example" run` and it would fail due to:

> 1) Error injecting constructor, java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.introspect.AnnotatedMember.getType(Lcom/fasterxml/jackson/databind/type/TypeBindings;)Lcom/fasterxml/jackson/databind/JavaType;

Full log:

```
$ sbt "project hello-world-example" run
[info] Loading settings for project finatra-swagger-build from plugins.sbt ...
[info] Loading project definition from /Users/yihongc/workspace/finatra-swagger/project
[info] Loading settings for project finatra-swagger from version.sbt,build.sbt ...
[info] Set current project to finatra-swagger (in build file:/Users/yihongc/workspace/finatra-swagger/)
[info] Set current project to hello-world-example (in build file:/Users/yihongc/workspace/finatra-swagger/)
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] Compile / run / javaOptions will be ignored, Compile / run / fork is set to false
[info] running com.jakehschwartz.finatra.swagger.SampleAppMain
13:02:54.446 [run-main-0] INFO com.twitter.util.logging.Slf4jBridgeUtility$ - org.slf4j.bridge.SLF4JBridgeHandler installed.
13:02:54.761 [run-main-0] DEBUG io.netty.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
13:02:54.770 [run-main-0] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.level: simple
13:02:54.770 [run-main-0] DEBUG io.netty.util.ResourceLeakDetector - -Dio.netty.leakDetection.targetRecords: 4
13:02:54.778 [run-main-0] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@4205dc58
13:02:54.840 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - Platform: MacOS
13:02:54.843 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - -Dio.netty.noUnsafe: false
13:02:54.844 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - Java version: 8
13:02:54.845 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.theUnsafe: available
13:02:54.846 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - sun.misc.Unsafe.copyMemory: available
13:02:54.847 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Buffer.address: available
13:02:54.848 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - direct buffer constructor: available
13:02:54.849 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.Bits.unaligned: available, true
13:02:54.850 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
13:02:54.850 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent0 - java.nio.DirectByteBuffer.<init>(long, int): available
13:02:54.850 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - sun.misc.Unsafe: available
13:02:54.850 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.tmpdir: /var/folders/m4/y93k16nd7019sgrmrfg0zmxh0000gp/T (java.io.tmpdir)
13:02:54.850 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.bitMode: 64 (sun.arch.data.model)
13:02:54.852 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.maxDirectMemory: 1029177344 bytes
13:02:54.852 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.uninitializedArrayAllocationThreshold: -1
13:02:54.854 [run-main-0] DEBUG io.netty.util.internal.CleanerJava6 - java.nio.ByteBuffer.cleaner(): available
13:02:54.854 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - -Dio.netty.noPreferDirect: false
13:02:54.872 [run-main-0] DEBUG io.netty.util.internal.PlatformDependent - org.jctools-core.MpscChunkedArrayQueue: available
13:02:55.414 [run-main-0] INFO com.twitter.finagle.http.HttpMuxer$ - HttpMuxer[/admin/metrics.json] = com.twitter.finagle.stats.MetricsExporter(com.twitter.finagle.stats.MetricsExporter)
13:02:55.415 [run-main-0] INFO com.twitter.finagle.http.HttpMuxer$ - HttpMuxer[/admin/per_host_metrics.json] = com.twitter.finagle.stats.HostMetricsExporter(com.twitter.finagle.stats.HostMetricsExporter)
13:02:55.626 [run-main-0] INFO com.jakehschwartz.finatra.swagger.SampleAppMain$ - Process started
13:02:55.786 [run-main-0] DEBUG com.jakehschwartz.finatra.swagger.SampleAppMain$ - AdminHttpServer Muxer endpoints:
        /admin/logging => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.NoLoggingHandler)
        /admin/ping => com.twitter.server.handler.ReplyHandler
         => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.AdminRedirectHandler)
        /admin => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.SummaryHandler)
        /admin/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.view.NotFoundView.andThen(com.twitter.server.handler.AdminRedirectHandler))
        /admin/server_info => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.view.TextBlockView.andThen(com.twitter.server.handler.ServerInfoHandler))
        /admin/contention => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.view.TextBlockView.andThen(com.twitter.server.handler.ContentionHandler))
        /admin/lint => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.LintHandler)
        /admin/lint.json => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.LintHandler)
        /admin/failedlint => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.FailedLintRuleHandler)
        /admin/threads => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ThreadsHandler)
        /admin/threads.json => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ThreadsHandler)
        /admin/announcer => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.view.TextBlockView.andThen(com.twitter.server.handler.AnnouncerHandler))
        /admin/dtab => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.DtabHandler)
        /admin/pprof/heap => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.HeapResourceHandler)
        /admin/pprof/profile => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ProfileResourceHandler)
        /admin/pprof/contention => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ProfileResourceHandler)
        /admin/shutdown => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ShutdownHandler)
        /admin/tracing => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.TracingHandler)
        /admin/metrics => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.MetricQueryHandler)
        /admin/metric_metadata.json => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.MetricMetadataQueryHandler)
        /admin/clients/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ClientRegistryHandler)
        /admin/balancers.json => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.LoadBalancersHandler)
        /admin/servers/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ServerRegistryHandler)
        /admin/files/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ResourceHandler)
        /admin/registry.json => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.RegistryHandler)
        /admin/toggles => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ToggleHandler)
        /admin/toggles/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ToggleHandler)
        /admin/tunables => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.TunableHandler)
        /admin/tunables/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.TunableHandler)
        /favicon.ico => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.ResourceHandler)
        /admin/servers/connections/ => com.twitter.finagle.filter.OffloadFilter$Server.andThen(com.twitter.server.handler.AttachedClientsHandler)
        /admin/histograms => com.twitter.server.handler.HistogramQueryHandler
        /admin/histograms.json => com.twitter.server.handler.HistogramQueryHandler
        /admin/exp/metric_metadata => com.twitter.server.handler.MetricTypeQueryHandler
13:02:55.802 [run-main-0] INFO com.jakehschwartz.finatra.swagger.SampleAppMain$ - Serving admin http on 0.0.0.0/0.0.0.0:9990
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numHeapArenas: 32
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.numDirectArenas: 32
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.pageSize: 8192
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxOrder: 7
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.chunkSize: 1048576
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.tinyCacheSize: 512
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.smallCacheSize: 256
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.normalCacheSize: 64
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedBufferCapacity: 32768
13:02:56.413 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimInterval: 8192
13:02:56.414 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.cacheTrimIntervalMillis: 0
13:02:56.414 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.useCacheForAllThreads: true
13:02:56.414 [run-main-0] DEBUG io.netty.buffer.PooledByteBufAllocator - -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
13:02:56.419 [run-main-0] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
13:02:56.419 [run-main-0] DEBUG io.netty.util.internal.InternalThreadLocalMap - -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
13:02:56.447 [run-main-0] INFO com.twitter.finagle - Finagle version 20.6.0 (rev=5ac803ba15a346c59cca7f625965039fe5767e67) built at 20200624-010447
13:02:56.534 [run-main-0] DEBUG io.netty.channel.MultithreadEventLoopGroup - -Dio.netty.eventLoopThreads: 32
13:02:56.575 [run-main-0] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.noKeySetOptimization: false
13:02:56.575 [run-main-0] DEBUG io.netty.channel.nio.NioEventLoop - -Dio.netty.selectorAutoRebuildThreshold: 512
13:02:56.641 [run-main-0] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.processId: 46317 (auto-detected)
13:02:56.646 [run-main-0] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv4Stack: false
13:02:56.646 [run-main-0] DEBUG io.netty.util.NetUtil - -Djava.net.preferIPv6Addresses: false
13:02:56.661 [run-main-0] DEBUG io.netty.util.NetUtil - Loopback interface: lo0 (lo0, 0:0:0:0:0:0:0:1%lo0)
13:02:56.662 [run-main-0] DEBUG io.netty.util.NetUtil - Failed to get SOMAXCONN from sysctl and file /proc/sys/net/core/somaxconn. Default: 128
13:02:56.669 [run-main-0] DEBUG io.netty.channel.DefaultChannelId - -Dio.netty.machineId: 38:f9:d3:ff:fe:e4:fd:86 (auto-detected)
13:02:56.717 [run-main-0] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
13:02:56.717 [run-main-0] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 0
13:02:56.717 [run-main-0] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
13:02:57.329 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: https.announce =
13:02:57.334 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: dtab.add =
13:02:57.335 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.level = INFO
13:02:57.335 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: local.doc.root =
13:02:57.336 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: https.port =
13:02:57.337 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.async = true
13:02:57.338 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: http.name = http
13:02:57.339 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: http.shutdown.time = 1.minutes
13:02:57.340 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: maxRequestSize = 5242880.bytes
13:02:57.340 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.rollPolicy = Never
13:02:57.341 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: help = false
13:02:57.342 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.output = /dev/stderr
13:02:57.343 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: http.port = :8888
13:02:57.344 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.async.maxsize = 4096
13:02:57.346 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: https.name = https
13:02:57.347 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: http.response.charset.enabled = true
13:02:57.348 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.rotateCount = -1
13:02:57.349 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: swagger.docs.endpoint = /docs
13:02:57.350 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: doc.root =
13:02:57.350 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.async.inferClassNames = false
13:02:57.351 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: http.announce =
13:02:57.352 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: log.append = true
13:02:57.353 [run-main-0] DEBUG com.twitter.inject.app.internal.FlagsModule - Binding flag: admin.port = :9990
13:02:57.631 [run-main-0] INFO com.jakehschwartz.finatra.swagger.SampleAppMain$ - Resolving Finagle clients before warmup
13:02:57.641 [run-main-0] INFO com.jakehschwartz.finatra.swagger.SampleAppMain$ - Done resolving clients: [].
13:02:57.644 [run-main-0] DEBUG com.twitter.server.internal.FinagleBuildRevision$ - Resolved Finagle build revision: (rev=5ac803ba15a346c59cca7f625965039fe5767e67)
13:02:59.568 [run-main-0] DEBUG io.swagger.converter.ModelConverters - adding ModelConverter: io.swagger.scala.converter.SwaggerScalaModelConverter@24658a42
13:02:59.571 [run-main-0] DEBUG io.swagger.converter.ModelConverterContextImpl - resolveProperty class java.lang.String
13:02:59.572 [run-main-0] DEBUG io.swagger.jackson.ModelResolver - resolveProperty [simple type, class java.lang.String]
13:02:59.620 [run-main-0] DEBUG io.swagger.converter.ModelConverters - ModelConverters readAll with JsonView annotation from class com.jakehschwartz.finatra.swagger.Student
13:02:59.620 [run-main-0] DEBUG io.swagger.converter.ModelConverterContextImpl - resolve class com.jakehschwartz.finatra.swagger.Student
13:02:59.620 [run-main-0] DEBUG io.swagger.converter.ModelConverterContextImpl - trying extension io.swagger.scala.converter.SwaggerScalaModelConverter@24658a42
13:02:59.626 [run-main-0] DEBUG io.swagger.converter.ModelConverterContextImpl - defineModel Student io.swagger.models.ModelImpl@ec1ac8e7
com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) Error injecting constructor, java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.introspect.AnnotatedMember.getType(Lcom/fasterxml/jackson/databind/type/TypeBindings;)Lcom/fasterxml/jackson/databind/JavaType;
  at com.jakehschwartz.finatra.swagger.SampleController.<init>(SampleController.scala:18)
  while locating com.jakehschwartz.finatra.swagger.SampleController

1 error
        at com.google.inject.internal.InternalProvisionException.toProvisionException(InternalProvisionException.java:226)
        at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1053)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1081)
        at com.twitter.inject.Injector.instance(Injector.scala:23)
        at com.twitter.finatra.http.routing.HttpRouter.add(HttpRouter.scala:165)
        at com.jakehschwartz.finatra.swagger.SampleApp.configureHttp(SampleApp.scala:19)
        at com.twitter.finatra.http.HttpServer.postInjectorStartup(servers.scala:496)
        at com.twitter.finatra.http.HttpServer.postInjectorStartup$(servers.scala:493)
        at com.jakehschwartz.finatra.swagger.SampleApp.postInjectorStartup(SampleApp.scala:10)
        at com.twitter.inject.app.App.main(App.scala:135)
        at com.twitter.inject.app.App.main$(App.scala:131)
        at com.twitter.inject.server.TwitterServer.main(TwitterServer.scala:168)
        at com.twitter.inject.server.TwitterServer.main$(TwitterServer.scala:167)
        at com.jakehschwartz.finatra.swagger.SampleApp.main(SampleApp.scala:10)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.twitter.app.App.$anonfun$nonExitingMain$4(App.scala:362)
        at scala.Option.foreach(Option.scala:407)
        at com.twitter.app.App.nonExitingMain(App.scala:361)
        at com.twitter.app.App.nonExitingMain$(App.scala:344)
        at com.jakehschwartz.finatra.swagger.SampleApp.nonExitingMain(SampleApp.scala:10)
        at com.twitter.app.App.main(App.scala:333)
        at com.twitter.app.App.main$(App.scala:331)
        at com.jakehschwartz.finatra.swagger.SampleApp.main(SampleApp.scala:10)
        at com.jakehschwartz.finatra.swagger.SampleAppMain.main(SampleApp.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sbt.Run.invokeMain(Run.scala:115)
        at sbt.Run.execute$1(Run.scala:79)
        at sbt.Run.$anonfun$runWithLoader$4(Run.scala:92)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at sbt.util.InterfaceUtil$$anon$1.get(InterfaceUtil.scala:10)
        at sbt.TrapExit$App.run(TrapExit.scala:257)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.introspect.AnnotatedMember.getType(Lcom/fasterxml/jackson/databind/type/TypeBindings;)Lcom/fasterxml/jackson/databind/JavaType;
        at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:425)
        at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:203)
        at io.swagger.scala.converter.SwaggerScalaModelConverter.resolve(SwaggerScalaModelConverter.scala:90)
        at io.swagger.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:103)
        at io.swagger.converter.ModelConverters.readAll(ModelConverters.java:98)
        at io.swagger.converter.ModelConverters.readAll(ModelConverters.java:88)
        at com.jakehschwartz.finatra.swagger.FinatraSwagger.registerModel(FinatraSwagger.scala:243)
        at com.jakehschwartz.finatra.swagger.FinatraSwagger.registerModel(FinatraSwagger.scala:237)
        at com.jakehschwartz.finatra.swagger.FinatraOperation.responseWith(FinatraOperation.scala:112)
        at com.jakehschwartz.finatra.swagger.SampleController.$anonfun$new$1(SampleController.scala:28)
        at com.twitter.finatra.http.SwaggerRouteDSL.registerOperation(SwaggerRouteDSL.scala:116)
        at com.twitter.finatra.http.SwaggerRouteDSL.getWithDoc(SwaggerRouteDSL.scala:40)
        at com.twitter.finatra.http.SwaggerRouteDSL.getWithDoc$(SwaggerRouteDSL.scala:33)
        at com.jakehschwartz.finatra.swagger.SampleController.getWithDoc(SampleController.scala:18)
        at com.jakehschwartz.finatra.swagger.SampleController.<init>(SampleController.scala:31)
        at com.jakehschwartz.finatra.swagger.SampleController$$FastClassByGuice$$e0cf5859.newInstance(<generated>)
        at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:89)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:306)
        at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1050)
        ... 36 more
Exception thrown in main on startup


Exception: sbt.TrapExitSecurityException thrown from the UncaughtExceptionHandler in thread "run-main-0"
[error] Nonzero exit code: 1
[error] (Compile / run) Nonzero exit code: 1
[error] Total time: 12 s, completed Jun 29, 2020 1:02:59 PM
```